### PR TITLE
feat(upcloud): validate `max-nodes-total` against cluster plan

### DIFF
--- a/cluster-autoscaler/cloudprovider/upcloud/mocks/upcloud.go
+++ b/cluster-autoscaler/cloudprovider/upcloud/mocks/upcloud.go
@@ -1,0 +1,58 @@
+package mocks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/upcloud/pkg/github.com/upcloudltd/upcloud-go-api/v6/upcloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/upcloud/pkg/github.com/upcloudltd/upcloud-go-api/v6/upcloud/request"
+)
+
+type UpCloudService struct {
+	Clusters   []upcloud.KubernetesCluster
+	Plans      []upcloud.KubernetesPlan
+	NodeGroups []upcloud.KubernetesNodeGroup
+}
+
+func (s *UpCloudService) GetKubernetesNodeGroups(ctx context.Context, r *request.GetKubernetesNodeGroupsRequest) ([]upcloud.KubernetesNodeGroup, error) {
+	return s.NodeGroups, nil
+
+}
+func (s *UpCloudService) ModifyKubernetesNodeGroup(ctx context.Context, r *request.ModifyKubernetesNodeGroupRequest) (*upcloud.KubernetesNodeGroup, error) {
+	for i := range s.NodeGroups {
+		if s.NodeGroups[i].Name == r.Name {
+			s.NodeGroups[i].Count = r.NodeGroup.Count
+			return &s.NodeGroups[i], nil
+		}
+	}
+	return nil, fmt.Errorf("node group not found %+v", r)
+}
+
+func (s *UpCloudService) DeleteKubernetesNodeGroupNode(ctx context.Context, r *request.DeleteKubernetesNodeGroupNodeRequest) error {
+	return nil
+}
+
+func (s *UpCloudService) GetKubernetesNodeGroup(ctx context.Context, r *request.GetKubernetesNodeGroupRequest) (*upcloud.KubernetesNodeGroupDetails, error) {
+	for i := range s.NodeGroups {
+		if s.NodeGroups[i].Name == r.Name {
+			return &upcloud.KubernetesNodeGroupDetails{
+				KubernetesNodeGroup: s.NodeGroups[i],
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("node group details not found %+v", r)
+}
+
+func (s *UpCloudService) GetKubernetesCluster(ctx context.Context, r *request.GetKubernetesClusterRequest) (*upcloud.KubernetesCluster, error) {
+	for i := range s.Clusters {
+		if s.Clusters[i].UUID == r.UUID {
+			return &s.Clusters[i], nil
+		}
+	}
+	return nil, &upcloud.Problem{Status: http.StatusNotFound}
+}
+
+func (s *UpCloudService) GetKubernetesPlans(ctx context.Context, r *request.GetKubernetesPlansRequest) ([]upcloud.KubernetesPlan, error) {
+	return s.Plans, nil
+}

--- a/cluster-autoscaler/cloudprovider/upcloud/upcloud_manager_internal_test.go
+++ b/cluster-autoscaler/cloudprovider/upcloud/upcloud_manager_internal_test.go
@@ -1,0 +1,52 @@
+package upcloud
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/upcloud/mocks"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/upcloud/pkg/github.com/upcloudltd/upcloud-go-api/v6/upcloud"
+)
+
+func TestClusterMaxNodes(t *testing.T) {
+	t.Parallel()
+
+	clusterUUID := uuid.New()
+	mock := mocks.UpCloudService{
+		Clusters: []upcloud.KubernetesCluster{{
+			UUID: clusterUUID.String(),
+			Plan: "dev",
+		}},
+		Plans: []upcloud.KubernetesPlan{{
+			Name:     "dev",
+			MaxNodes: 20,
+		}},
+	}
+	want := 10
+	got, err := clusterMaxNodes(context.TODO(), &mock, clusterUUID, 10)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+
+	got, err = clusterMaxNodes(context.TODO(), &mock, clusterUUID, 0)
+	require.NoError(t, err)
+	require.Equal(t, mock.Plans[0].MaxNodes, got)
+
+	_, err = clusterMaxNodes(context.TODO(), &mock, clusterUUID, 100)
+	require.Error(t, err)
+}
+
+func TestClusterPlanByName(t *testing.T) {
+	t.Parallel()
+
+	want := upcloud.KubernetesPlan{
+		Name: "match",
+	}
+	mock := mocks.UpCloudService{
+		Plans: []upcloud.KubernetesPlan{want},
+	}
+	got, err := clusterPlanByName(context.TODO(), &mock, want.Name)
+	require.NoError(t, err)
+	require.Equal(t, want.Name, got.Name)
+}

--- a/cluster-autoscaler/cloudprovider/upcloud/upcloud_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/upcloud/upcloud_node_group_test.go
@@ -1,7 +1,6 @@
 package upcloud
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -10,33 +9,43 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/upcloud/mocks"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/upcloud/pkg/github.com/upcloudltd/upcloud-go-api/v6/upcloud"
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/upcloud/pkg/github.com/upcloudltd/upcloud-go-api/v6/upcloud/request"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 )
 
 func TestUpCloudNodeGroup_Id(t *testing.T) {
+	t.Parallel()
+
 	g := &UpCloudNodeGroup{clusterID: uuid.New(), name: "test"}
 	require.Equal(t, fmt.Sprintf("%s/%s", g.clusterID.String(), g.name), g.Id())
 }
 
 func TestUpCloudNodeGroup_MinSize(t *testing.T) {
+	t.Parallel()
+
 	g := &UpCloudNodeGroup{minSize: 1}
 	require.Equal(t, 1, g.MinSize())
 }
 func TestUpCloudNodeGroup_MaxSize(t *testing.T) {
+	t.Parallel()
+
 	g := &UpCloudNodeGroup{maxSize: 1}
 	require.Equal(t, 1, g.MaxSize())
 }
 func TestUpCloudNodeGroup_TargetSize(t *testing.T) {
+	t.Parallel()
+
 	g := &UpCloudNodeGroup{size: 1}
 	size, err := g.TargetSize()
 	require.NoError(t, err)
 	require.Equal(t, 1, size)
 }
 func TestUpCloudNodeGroup_IncreaseSize(t *testing.T) {
-	svc := upCloudServiceMock{
-		nodeGroups: []upcloud.KubernetesNodeGroup{
+	t.Parallel()
+
+	svc := mocks.UpCloudService{
+		NodeGroups: []upcloud.KubernetesNodeGroup{
 			{
 				Name:  "test",
 				Count: 1,
@@ -50,8 +59,10 @@ func TestUpCloudNodeGroup_IncreaseSize(t *testing.T) {
 	require.Equal(t, 2, size)
 }
 func TestUpCloudNodeGroup_DecreaseTargetSize(t *testing.T) {
-	svc := upCloudServiceMock{
-		nodeGroups: []upcloud.KubernetesNodeGroup{
+	t.Parallel()
+
+	svc := mocks.UpCloudService{
+		NodeGroups: []upcloud.KubernetesNodeGroup{
 			{
 				Name:  "test",
 				Count: 3,
@@ -65,8 +76,10 @@ func TestUpCloudNodeGroup_DecreaseTargetSize(t *testing.T) {
 	require.Equal(t, 2, size)
 }
 func TestUpCloudNodeGroup_DeleteNodes(t *testing.T) {
-	svc := upCloudServiceMock{
-		nodeGroups: []upcloud.KubernetesNodeGroup{
+	t.Parallel()
+
+	svc := mocks.UpCloudService{
+		NodeGroups: []upcloud.KubernetesNodeGroup{
 			{
 				Name:  "test",
 				Count: 1,
@@ -83,6 +96,8 @@ func TestUpCloudNodeGroup_DeleteNodes(t *testing.T) {
 	require.Equal(t, 1, size)
 }
 func TestUpCloudNodeGroup_Nodes(t *testing.T) {
+	t.Parallel()
+
 	wantNodes := []cloudprovider.Instance{{
 		Id: "test",
 	}}
@@ -92,67 +107,48 @@ func TestUpCloudNodeGroup_Nodes(t *testing.T) {
 	require.Equal(t, wantNodes, gotNodes)
 }
 func TestUpCloudNodeGroup_Autoprovisioned(t *testing.T) {
+	t.Parallel()
+
 	g := &UpCloudNodeGroup{}
 	require.False(t, g.Autoprovisioned())
 }
 func TestUpCloudNodeGroup_Create(t *testing.T) {
+	t.Parallel()
+
 	g := &UpCloudNodeGroup{}
 	_, err := g.Create()
 	require.ErrorIs(t, err, cloudprovider.ErrNotImplemented)
 }
 func TestUpCloudNodeGroup_Delete(t *testing.T) {
+	t.Parallel()
+
 	g := &UpCloudNodeGroup{}
 	err := g.Delete()
 	require.ErrorIs(t, err, cloudprovider.ErrNotImplemented)
 }
 func TestUpCloudNodeGroup_GetOptions(t *testing.T) {
+	t.Parallel()
+
 	g := &UpCloudNodeGroup{}
 	_, err := g.GetOptions(config.NodeGroupAutoscalingOptions{})
 	require.ErrorIs(t, err, cloudprovider.ErrNotImplemented)
 }
 func TestUpCloudNodeGroup_Debug(t *testing.T) {
+	t.Parallel()
+
 	g := &UpCloudNodeGroup{name: "test"}
 	require.NotEmpty(t, g.Debug())
 }
 func TestUpCloudNodeGroup_Exist(t *testing.T) {
+	t.Parallel()
+
 	g := &UpCloudNodeGroup{name: "test"}
 	require.True(t, g.Exist())
 }
 func TestUpCloudNodeGroup_TemplateNodeInfo(t *testing.T) {
+	t.Parallel()
+
 	g := &UpCloudNodeGroup{}
 	_, err := g.TemplateNodeInfo()
 	require.ErrorIs(t, err, cloudprovider.ErrNotImplemented)
-}
-
-type upCloudServiceMock struct {
-	nodeGroups         []upcloud.KubernetesNodeGroup
-	detailedNodeGroups []upcloud.KubernetesNodeGroupDetails
-}
-
-func (s *upCloudServiceMock) GetKubernetesNodeGroups(ctx context.Context, r *request.GetKubernetesNodeGroupsRequest) ([]upcloud.KubernetesNodeGroup, error) {
-	return s.nodeGroups, nil
-
-}
-func (s *upCloudServiceMock) ModifyKubernetesNodeGroup(ctx context.Context, r *request.ModifyKubernetesNodeGroupRequest) (*upcloud.KubernetesNodeGroup, error) {
-	for i := range s.nodeGroups {
-		if s.nodeGroups[i].Name == r.Name {
-			s.nodeGroups[i].Count = r.NodeGroup.Count
-			return &s.nodeGroups[i], nil
-		}
-	}
-	return nil, fmt.Errorf("node group not found %+v", r)
-}
-
-func (s *upCloudServiceMock) DeleteKubernetesNodeGroupNode(ctx context.Context, r *request.DeleteKubernetesNodeGroupNodeRequest) error {
-	return nil
-}
-
-func (s *upCloudServiceMock) GetKubernetesNodeGroup(ctx context.Context, r *request.GetKubernetesNodeGroupRequest) (*upcloud.KubernetesNodeGroupDetails, error) {
-	for i := range s.detailedNodeGroups {
-		g := s.detailedNodeGroups[i]
-		if g.Name == r.Name {
-			return &g, nil
-		}
-	}
-	return nil, fmt.Errorf("node group details not found %+v", r)
 }


### PR DESCRIPTION
- check that maximum number of nodes in the cluster is aligned with the cluster plan
- small refactoring to make code more testable
- new `upCloudConfig` type to represent provider configuration