### PR TITLE
chore(image): build CA v1.28 & v1.27 images

### DIFF
--- a/.github/workflows/upcloud_publish_v1_27.yml
+++ b/.github/workflows/upcloud_publish_v1_27.yml
@@ -50,12 +50,17 @@ jobs:
           CGO_ENABLED: "0"
         run: go build -ldflags "-w -s" --tags upcloud -o cloudprovider/upcloud/cluster-autoscaler-${{ env.GOARCH }}
 
+      - name: Get CA version
+        id: ca
+        working-directory: cluster-autoscaler/
+        run: echo "ca_version=$(./cloudprovider/upcloud/hack/version.sh)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           file: cluster-autoscaler/Dockerfile.${{ env.GOARCH }}
           context: cluster-autoscaler/cloudprovider/upcloud/
           push: true
-          tags: "ghcr.io/upcloudltd/autoscaler:v1.27"
+          tags: "ghcr.io/upcloudltd/autoscaler:v${{ steps.ca.outputs.ca_version }}"
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64

--- a/.github/workflows/upcloud_publish_v1_27.yml
+++ b/.github/workflows/upcloud_publish_v1_27.yml
@@ -1,0 +1,61 @@
+name: Publish UpCloud Provider (CA v1.27)
+
+on:
+  push:
+    branches:
+      - "feat/cluster-autoscaler-cloudprovider-upcloud-1.27"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  GOOS: linux
+  GOARCH: amd64
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: feat/cluster-autoscaler-cloudprovider-upcloud-1.27
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.GH_USER }}
+          password: ${{ secrets.GH_PAT }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v2
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Set go environment
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+
+      - name: Build Go binary
+        working-directory: cluster-autoscaler/
+        env:
+          GOOS: ${{ env.GOOS }}
+          GOARCH: ${{ env.GOARCH }}
+          CGO_ENABLED: "0"
+        run: go build -ldflags "-w -s" --tags upcloud -o cloudprovider/upcloud/cluster-autoscaler-${{ env.GOARCH }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          file: cluster-autoscaler/Dockerfile.${{ env.GOARCH }}
+          context: cluster-autoscaler/cloudprovider/upcloud/
+          push: true
+          tags: "ghcr.io/upcloudltd/autoscaler:v1.27"
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64

--- a/.github/workflows/upcloud_publish_v1_28.yml
+++ b/.github/workflows/upcloud_publish_v1_28.yml
@@ -50,12 +50,17 @@ jobs:
           CGO_ENABLED: "0"
         run: go build -ldflags "-w -s" --tags upcloud -o cloudprovider/upcloud/cluster-autoscaler-${{ env.GOARCH }}
 
+      - name: Get CA version
+        id: ca
+        working-directory: cluster-autoscaler/
+        run: echo "ca_version=$(./cloudprovider/upcloud/hack/version.sh)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           file: cluster-autoscaler/Dockerfile.${{ env.GOARCH }}
           context: cluster-autoscaler/cloudprovider/upcloud/
           push: true
-          tags: "ghcr.io/upcloudltd/autoscaler:v1.28"
+          tags: "ghcr.io/upcloudltd/autoscaler:v${{ steps.ca.outputs.ca_version }}"
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64

--- a/.github/workflows/upcloud_publish_v1_28.yml
+++ b/.github/workflows/upcloud_publish_v1_28.yml
@@ -1,8 +1,9 @@
-name: Publish UpCloud Provider
+name: Publish UpCloud Provider (CA v1.28)
 
 on:
   push:
-    tags: ["v*.*.*"]
+    branches:
+      - "feat/cluster-autoscaler-cloudprovider-upcloud-1.28"
 
 env:
   REGISTRY: ghcr.io
@@ -21,7 +22,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: feat/cluster-autoscaler-cloudprovider-upcloud
+          ref: feat/cluster-autoscaler-cloudprovider-upcloud-1.28
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -55,6 +56,6 @@ jobs:
           file: cluster-autoscaler/Dockerfile.${{ env.GOARCH }}
           context: cluster-autoscaler/cloudprovider/upcloud/
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: "ghcr.io/upcloudltd/autoscaler:v1.28"
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64

--- a/cluster-autoscaler/cloudprovider/upcloud/hack/version.sh
+++ b/cluster-autoscaler/cloudprovider/upcloud/hack/version.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright 2014 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+version_file=`dirname "$0"`/../../../version/version.go
+grep '^const ClusterAutoscalerVersion = "' $version_file | cut -d'"' -f2


### PR DESCRIPTION
Build images based on CA 1.28 & 1.27 instead of what is tagged in this branch.  